### PR TITLE
[KLC-1329] Update klever-docs Links o recently release testnet ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+.idea
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,98 @@
 # Klever Documentation
 
-Documentation about implementation of extension.
+Welcome to the **Klever** open-source documentation repository! This project is built using [Next.js](https://nextjs.org/) to provide a fast, scalable, and modern platform for documenting Klever's products and services. We invite the community to contribute and help improve our documentation.
+
+---
+
+## Table of Contents
+1. [Getting Started](#getting-started)
+2. [Installation](#installation)
+3. [Running the Project](#running-the-project)
+4. [How to Contribute](#how-to-contribute)
+
+---
+
+## Getting Started
+
+### Prerequisites
+- **Node.js** (version 20 or higher recommended)
+- **npm** (comes bundled with Node.js) or [Yarn](https://classic.yarnpkg.com/) (optional)
+
+Make sure you have Node.js installed on your machine. You can verify this by running:
+
+```bash
+node -v
+```
+
+If you do not have Node.js installed, you can download it from the official [Node.js website](https://nodejs.org/).
+
+---
+
+## Installation
+
+1. **Clone the repository** (or download the ZIP)
+   ```bash
+   git clone https://github.com/klever-io/klever-docs.git
+   ```
+
+2. **Navigate to the project folder**
+   ```bash
+   cd klever-docs
+   ```
+
+3. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   or
+   ```bash
+   yarn
+   ```
+
+---
+
+## Running the Project
+
+To run the development server locally:
+
+```bash
+npm run dev
+```
+
+This starts the Next.js development server on [http://localhost:3000](http://localhost:3000).  
+You can visit that URL in your browser to see the documentation site running locally.
+
+---
+
+## How to Contribute
+
+We welcome and appreciate all contributions, big or small! Here’s how you can help:
+
+1. **Fork the Repository**  
+   Click the "Fork" button on the top right of this repository page to create a copy of this project in your GitHub account.
+
+2. **Create a New Branch**  
+   Once you have forked the project, create a new branch for your feature or bug fix.
+   ```bash
+   git checkout -b feature-or-bugfix-name
+   ```
+
+3. **Make Your Changes**  
+   Edit the documentation files, add new pages, or fix any issues.
+
+4. **Commit and Push**  
+   Commit your changes with a clear message describing the update:
+   ```bash
+   git add .
+   git commit -m "Add some awesome feature to the documentation"
+   git push origin feature-or-bugfix-name
+   ```
+
+5. **Open a Pull Request**  
+   Go to your fork on GitHub, and you’ll see a button to “Compare & pull request.” Open a PR against the original **klever-io/klever-docs** repository. Provide a clear description of the changes you've made and why they should be merged.
+
+### Guidelines
+- Provide a clear and concise commit message.
+- Write clear and descriptive PR descriptions.
+- Adhere to the project structure and formatting conventions.
+- Ensure that your changes do not break the build (the site should still run locally with `npm run dev`).

--- a/src/app/node-operations/page.mdx
+++ b/src/app/node-operations/page.mdx
@@ -123,7 +123,7 @@ curl -k https://backup.mainnet.klever.finance/config.mainnet.108.tar.gz \
 _For TestNet_
 
 ```bash
-curl -k https://backup.testnet.klever.finance/config.testnet.100420.tar.gz \
+curl -k https://backup.testnet.klever.org/config.testnet.109.tar.gz \
     | tar -xz -C ./node
 ```
 

--- a/src/app/node.js/page.mdx
+++ b/src/app/node.js/page.mdx
@@ -120,7 +120,7 @@ import { Transaction, Contracts, TXContract_ContractType, utils } from "@klever/
       BandwidthFee: 1000000,
       KAppFee: 500000,
       Version: 1,
-      ChainID: enc.encode("100420")
+      ChainID: enc.encode("109")
     });
 
   // add contract to transaction

--- a/src/app/testnet/page.mdx
+++ b/src/app/testnet/page.mdx
@@ -4,7 +4,7 @@ export const metadata = {'title': 'testnet', 'description': 'Content for testnet
 
 How to interact with testnet
 
-To run an observer node or a validator on the testnet you can follow all the same steps of the mainnet, just changing the docker image from `kleverapp/klever-go:latest` to `kleverapp/klever-go:latest-testnet` and the config files download URL from `config.mainnet.108.tar.gz` to `config.testnet.100420.tar.gz`
+To run an observer node or a validator on the testnet you can follow [all the same steps of the mainnet](/node-operations#how-to-run-a-node), just changing the docker image from `kleverapp/klever-go:latest` to `kleverapp/klever-go:latest-testnet` and the config files you can download from [https://backup.testnet.klever.org/config.testnet.109.tar.gz](https://backup.testnet.klever.org/config.testnet.109.tar.gz)
 
 You can use the [Testnet Explorer](https://testnet.kleverscan.org/) to view and interact with all testnet features.
 


### PR DESCRIPTION
This pull request includes updates to the configuration and documentation for the testnet environment. The most important changes involve updating URLs and encoded values to reflect the latest testnet version.

Updates to testnet configuration:

* [`src/app/node-operations/page.mdx`](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL126-R126): Updated the URL for downloading the testnet configuration files.
* [`src/app/node.js/page.mdx`](diffhunk://#diff-6d21a32a8b785555220e72b82e65958b9db9f34b1676f31181f361a171fc6f53L123-R123): Changed the `ChainID` encoding to reflect the new testnet version.
* [`src/app/testnet/page.mdx`](diffhunk://#diff-04c6e4d42662f8117b7c4cafe39a971e18e534273e3ca3e47627720b0cea6f12L7-R7): Updated the instructions and URL for downloading testnet configuration files and added a link to the mainnet node operation steps.