### PR TITLE
Document new field currencyAmount of ITOBuy

### DIFF
--- a/src/app/contract-details/page.mdx
+++ b/src/app/contract-details/page.mdx
@@ -545,12 +545,13 @@ Creates a buy (or bid) order for a given market sell order.
 
 ### Payload Parameters
 
-| Required | Parameter  | Type   | Description                                                                                       |
-| -------- | ---------- | ------ | ------------------------------------------------------------------------------------------------- |
-| ✅       | buyType    | number | 0: ITOBuy, 1: MarketBuy                                                                           |
-| ✅       | id         | string | ITOBuy: ITO Asset ID, MarketBuy: order ID                                                         |
-| ✅       | currencyId | string | ID of the trade currency                                                                          |
-| ✅       | amount     | number | ITOBuy: Amount to be bought, MarkeyBuy: item price / amount bidden(check [precision](/precision)) |
+| Required | Parameter        | Type   | Description                                                                                       |
+| -------- | ---------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| ✅       | buyType          | number | 0: ITOBuy, 1: MarketBuy                                                                           |
+| ✅       | id               | string | ITOBuy: ITO Asset ID, MarketBuy: order ID                                                         |
+| ✅       | currencyId       | string | ID of the trade currency                                                                          |
+| ✅       | amount           | number | ITOBuy: Amount to be bought, MarkeyBuy: item price / amount bidden(check [precision](/precision)) |
+| ✅       | currencyAmount   | number | ITOBuy: Amount to be spent, MarkeyBuy: Not used                                                   |
 
 **_Send the 'amount' parameter with the correct [precision](/precision) based on the currency asset_**
 

--- a/src/app/node-operations/page.mdx
+++ b/src/app/node-operations/page.mdx
@@ -1506,11 +1506,12 @@ operator kapps buy [flags]
 ### Options
 
 ```
-      --amount float   set a buy amount
-  -h, --help           help for buy
-      --id string      set a buy ID
-      --kda string     set a KDA ID
-      --type int32     set a buy type
+      --amount float            set a buy amount
+      --currencyAmount float    locks the currency amount to be spent
+  -h, --help                    help for buy
+      --id string               set a buy ID
+      --kda string              set a KDA ID
+      --type int32              set a buy type
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This pull request includes updates to the documentation for creating buy orders and node operations. The changes primarily focus on adding a new parameter and updating the documentation tables to reflect this addition.

Documentation updates:

* [`src/app/contract-details/page.mdx`](diffhunk://#diff-4fd4333857afebee4b4b503f456a503fc0bb0d8aa99fbc3d6dc2f0fedc9e1d99L549-R554): Added the `currencyAmount` parameter to the payload parameters table for buy orders. This parameter specifies the amount to be spent for `ITOBuy` and is not used for `MarketBuy`.
* [`src/app/node-operations/page.mdx`](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR1510): Added the `--currencyAmount` flag to the command options for the `buy` operation, which locks the currency amount to be spent.