### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/src/app/about-our-technology/page.mdx
+++ b/src/app/about-our-technology/page.mdx
@@ -164,7 +164,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     kda trigger 15 --kdaID=YOUR_KDA_ID --updateKdaPool='active=true,adminAddress=yourAddress,fixedRatioKLV=KLVRATIO,fixedRatioKDA=KDARATIO'
 ```
 
@@ -179,7 +179,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     kda deposit AMOUNT --depositType=1 --kdaID=YOUR_KDA_ID --currencyID=KLV
 ```
 
@@ -288,7 +288,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     kda create 0 --canBurn=true --canMint=true --canFreeze=true --canPause=true --canWipe=true --logo=LOGO_URL --maxSupply=AMOUNT_MAX --precision=6 --name=KDA_NAME --ticker=KDA_TICKER
 ```
 

--- a/src/app/account-permissions/page.mdx
+++ b/src/app/account-permissions/page.mdx
@@ -138,7 +138,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account permission --perm='your-permission-here'
 ```
 
@@ -151,7 +151,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account permission --perm='{"type":1,"threshold":2,"operations":"01af","permissionName": "Klever Permission!" "signers":[{"address":"Address-A","weight":1},{"address":"Address-B","weight":1},{"address":"Address-C","weight":2}]}'
 ```
 

--- a/src/app/api-and-sdk/page.mdx
+++ b/src/app/api-and-sdk/page.mdx
@@ -61,22 +61,22 @@ If you need more info on the Kleverchain APIs to interact directly with the bloc
 ### Proxy API endpoints
 
 Proxy API endpoints
-[Swagger UI](https://api.testnet.klever.finance/swagger/index.html)
+[Swagger UI](https://api.testnet.klever.org/swagger/index.html)
 
 ### Node API endpoints
 
 Node API endpoints
-[Swagger UI](https://node.testnet.klever.finance/swagger/index.html)
+[Swagger UI](https://node.testnet.klever.org/swagger/index.html)
 
 ### Multi-Signature API
 
 Create and handle transactions with multiple signatures accounts:
-[MultiSig API Reference](https://docs.klever.finance/api-and-sdk/multisig-api-reference)
+[MultiSig API Reference](https://docs.klever.org/api-and-sdk/multisig-api-reference)
 
 ### WebSocket
 
 Receive blocks, addresses and transactions from our WebSocket:
-[Websocket Reference](https://docs.klever.finance/api-and-sdk/websocket-reference)
+[Websocket Reference](https://docs.klever.org/api-and-sdk/websocket-reference)
 
 ## Checking the status of the transaction
 
@@ -86,9 +86,9 @@ Take the hash `7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882 
 
 You can either see the transaction details [using the Klever Explorer](https://kleverscan.org/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882) or by calling one of the api endpoint's.
 
-[Using the proxy api call](https://api.mainnet.klever.finance/v1.0/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the parsed transaction as response.
+[Using the proxy api call](https://api.mainnet.klever.org/v1.0/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the parsed transaction as response.
 
-[Using the node api call](https://node.mainnet.klever.finance/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the transaction as it is in the blockchain.
+[Using the node api call](https://node.mainnet.klever.org/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the transaction as it is in the blockchain.
 
 Using the explorer or the proxy api, you can check the status code of the transaction, if it matches the expected format it will be "`success`".
 
@@ -113,7 +113,7 @@ const unsignedTransaction = await window.kleverWeb.buildTransaction([
 
 Even though you can use the window kleverWeb object directly, we suggest you [use the Kleverchain JS SDK,](/sdks) if you are using javascript.
 
-Alternatively you can send the params [through the `send` endpoint](https://node.mainnet.klever.finance/swagger/index.html#/Transaction/post_transaction_send), and will receive an unsigned transaction as response.
+Alternatively you can send the params [through the `send` endpoint](https://node.mainnet.klever.org/swagger/index.html#/Transaction/post_transaction_send), and will receive an unsigned transaction as response.
 
 ### 2. Sign
 
@@ -136,7 +136,7 @@ const broadcastResponse = await window.kleverWeb.broadcastTransactions([
 ])
 ```
 
-Alternatively you can send a signed transaction [through the `broadcast` endpoint](https://node.mainnet.klever.finance/swagger/index.html#/Transaction/post_transaction_broadcast) to be processed and validated by the blockchain.
+Alternatively you can send a signed transaction [through the `broadcast` endpoint](https://node.mainnet.klever.org/swagger/index.html#/Transaction/post_transaction_broadcast) to be processed and validated by the blockchain.
 
 ## Checking the status of the transaction
 
@@ -146,9 +146,9 @@ Take the hash `7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882 
 
 You can either see the transaction details [using the Klever Explorer](https://kleverscan.org/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882) or by calling one of the api endpoint's.
 
-[Using the proxy api call](https://api.mainnet.klever.finance/v1.0/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the parsed transaction as response.
+[Using the proxy api call](https://api.mainnet.klever.org/v1.0/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the parsed transaction as response.
 
-[Using the node api call](https://node.mainnet.klever.finance/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the transaction as it is in the blockchain.
+[Using the node api call](https://node.mainnet.klever.org/transaction/7b066e58b650d4ea6ba61de087350ddf909cfee660cc9537c0167b38df6d4882), you will receive the transaction as it is in the blockchain.
 
 Using the explorer or the proxy api, you can check the status code of the transaction, if it matches the expected format it will be "`success`".
 
@@ -176,7 +176,7 @@ If, for some reason, your transaction was broadcast but doesn't appear in the pr
 <CodeGroup
 	title="Create a new transaction or add a signature"
 	tag="POST"
-	label="https://multisign.mainnet.klever.finance/transaction"
+	label="https://multisign.mainnet.klever.org/transaction"
   code={bodyTransaction}
 	>
   <div>
@@ -228,19 +228,19 @@ If, for some reason, your transaction was broadcast but doesn't appear in the pr
 
 <CodeGroup
   tag="POST"
-  label="https://multisign.mainnet.klever.finance/broadcast/{hash}"
+  label="https://multisign.mainnet.klever.org/broadcast/{hash}"
   title="Broadcast the transaction if the threshold was reached"
 />
 
 <CodeGroup
   tag="GET"
-  label="https://multisign.mainnet.klever.finance/transaction/{hash}"
+  label="https://multisign.mainnet.klever.org/transaction/{hash}"
   title="List a transaction by hash"
 />
 
 <CodeGroup
   tag="GET"
-  label="https://multisign.mainnet.klever.finance/transaction/by-address/{address}"
+  label="https://multisign.mainnet.klever.org/transaction/by-address/{address}"
   title="List all transactions for an address"
 />
 
@@ -275,7 +275,7 @@ const (
 )
 
 func main() {
-	u := url.URL{Scheme: "wss", Host: "websocket.mainnet.klever.finance", Path: ""}
+	u := url.URL{Scheme: "wss", Host: "websocket.mainnet.klever.org", Path: ""}
 	log.Printf("connecting to %s", u.String())
 
 	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
@@ -337,7 +337,7 @@ export enum WSTopics {
   transaction = 'transaction', // receive all transactions
 }
 
-const socketUrl = "wss://websocket.mainnet.klever.finance"
+const socketUrl = "wss://websocket.mainnet.klever.org"
 
 const { sendJsonMessage, lastJsonMessage } = useWebSocket(socketUrl, {
     onOpen: () => {

--- a/src/app/api-and-sdk/page.mdx
+++ b/src/app/api-and-sdk/page.mdx
@@ -246,7 +246,7 @@ If, for some reason, your transaction was broadcast but doesn't appear in the pr
 
 ## Websocket Reference
 
-Here you will find a guide on establishing a connection to the Blockchain WebSocket client. This guide will walk you through the step-by-step process of connecting and receiving messages.
+Here you will find a guide on establishing a connection to the Blockchain WebSocket client. You must run your node with indexer option to have events subscription. This guide will walk you through the step-by-step process of connecting and receiving messages.
 
 ### How to receive messages:
 
@@ -261,21 +261,35 @@ To connect to the Blockchain WebSocket client, follow these steps.
 package main
 
 import (
-	"github.com/gorilla/websocket"
+	"encoding/json"
 	"log"
 	"net/url"
+
+	"github.com/gorilla/websocket"
 )
 
 type EventType string
 
 const (
-	ACCOUNTS         EventType = "accounts" // receive all accounts changed or created
-	BLOCKS           EventType = "blocks" // receive all blocks
-	TRANSACTION      EventType = "transaction" // receive all transactions
+	ACCOUNTS    EventType = "accounts"    // receive all accounts changed or created
+	BLOCKS      EventType = "blocks"      // receive all blocks
+	TRANSACTION EventType = "transaction" // receive all transactions
 )
 
+type Data struct {
+	Types     []EventType `json:"subcribed_types"`
+	Addresses []string    `json:"addresses"`
+}
+
+type Event struct {
+	Type    EventType `json:"type"`
+	Address string    `json:"address"`
+	Hash    string    `json:"hash"`
+	Data    []byte    `json:"data"`
+}
+
 func main() {
-	u := url.URL{Scheme: "wss", Host: "websocket.mainnet.klever.org", Path: ""}
+	u := url.URL{Scheme: "ws", Host: "127.0.0.1:8080", Path: "/subscribe"}
 	log.Printf("connecting to %s", u.String())
 
 	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
@@ -295,29 +309,31 @@ func main() {
 				return
 			}
 
-			log.Println(string(message))
+			// marshal the message to Event struct
+			var event Event
+			if err := json.Unmarshal(message, &event); err != nil {
+				log.Println("unmarshal:", err)
+				return
+			}
+
+			switch event.Type {
+			case BLOCKS:
+				log.Println("Received BLOCKS data:", string(event.Data))
+			case ACCOUNTS:
+				log.Println("Received ACCOUNTS data:", string(event.Data))
+			case TRANSACTION:
+				log.Println("Received TRANSACTION data:", string(event.Data))
+			default:
+				log.Println("Unknown data ", string(message))
+			}
+
 		}
 	}()
 
-	subMessage := struct {
-		Action string `json:"action"`
-		Data   struct {
-		        Address string `json:"address"`
-			Hash string `json:"hash"`
-			Topics []EventType `json:"topics"`
-		} `json:"data"`
-	}{
-		Action: "subscribe",
-		Data: struct {
-			Topics []EventType `json:"topics"`
-			Address string `json:"address"`
-			Hash string `json:"hash"`
-		}{
-			Topics: []EventType{indexer.ACCOUNTS},
-			Address: "klv1....", // OPTIONAL field to listen a specific address
-			Hash: "hash11.." // // OPTIONAL field to listen a specific tx hash
-		},
+	subMessage := Data{
+		Types: []EventType{BLOCKS, TRANSACTION, ACCOUNTS},
 	}
+
 	// send the first message to subscribe
 	if err := c.WriteJSON(subMessage); err != nil {
 		log.Println("err: ", err)
@@ -326,6 +342,7 @@ func main() {
 
 	<-done
 }
+
 ```
 
 ```javascript
@@ -337,17 +354,13 @@ export enum WSTopics {
   transaction = 'transaction', // receive all transactions
 }
 
-const socketUrl = "wss://websocket.mainnet.klever.org"
+const socketUrl = "ws://127.0.0.1:8080" // your indexer node
 
 const { sendJsonMessage, lastJsonMessage } = useWebSocket(socketUrl, {
     onOpen: () => {
       const payload = {
-        action: 'subscribe',
-        data: {
-          address: "klv1....", // OPTIONAL field to listen a specific address
-          topics: [WSTopics.blocks],
-          hash: "hash11.." // // OPTIONAL field to listen a specific tx hash
-        },
+        addresses: ["klv1...."], // OPTIONAL field to listen a specific address
+        subcribed_types: [WSTopics.blocks],
       }
       sendJsonMessage(payload)
     }

--- a/src/app/become-a-validator/page.mdx
+++ b/src/app/become-a-validator/page.mdx
@@ -15,13 +15,13 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     validator create \
     klv1h7vx629mwuv4pnecn0k9clxp9rt7rquat3kvydgu8npt20e0ntjq3jhd40 \
     --bls=ce3aa977d1028e2a91730259c4b66cd862b77c63253fa12932012288108a0b7f110da4a2e3e1c15cc94802a79afef418f9a724a1ebe1423c0fa897bae669f1735b082ff3f19b3e00acc76a2bb0f31b1856e3e55952655386fbedad9c55322b81 \
     --rewards=klv1h7vx629mwuv4pnecn0k9clxp9rt7rquat3kvydgu8npt20e0ntjq3jhd40 \
     --name=MyValidatorName \
-    --logo="https://klever.finance/wp-content/uploads/2021/09/logo.svg" \
+    --logo="https://klever.org/wp-content/uploads/2021/09/logo.svg" \
     --commission=5 \
     --maxDelegation=12000000 \
     --uris="github=github.com/klever-io"
@@ -57,7 +57,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance account freeze 10000000
+    --node=https://node.mainnet.klever.org account freeze 10000000
 ```
 
 After the "freeze" instruction, there is this structure: [AMOUNT].
@@ -80,7 +80,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account delegate \
     klv186vg5k3pqetmfuy04620htcvz3krugu7hqe4ukczdy48r222j78q9y8vm5 \
     --bucketID=db0748c562c413a68b21a75249e1b936339fc03513e0bf076d3850b7a81113d2
@@ -125,13 +125,13 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     validator config \
     klv1h7vx629mwuv4pnecn0k9clxp9rt7rquat3kvydgu8npt20e0ntjq3jhd40 \
     --bls=ce3aa977d1028e2a91730259c4b66cd862b77c63253fa12932012288108a0b7f110da4a2e3e1c15cc94802a79afef418f9a724a1ebe1423c0fa897bae669f1735b082ff3f19b3e00acc76a2bb0f31b1856e3e55952655386fbedad9c55322b81 \
     --rewards=klv1h7vx629mwuv4pnecn0k9clxp9rt7rquat3kvydgu8npt20e0ntjq3jhd40 \
     --name=MyValidatorName \
-    --logo="https://klever.finance/wp-content/uploads/2021/09/logo.svg" \
+    --logo="https://klever.org/wp-content/uploads/2021/09/logo.svg" \
     --commission=5 \
     --maxDelegation=12000000 \
     --uris="github=github.com/klever-io"

--- a/src/app/create-local-testnet/page.mdx
+++ b/src/app/create-local-testnet/page.mdx
@@ -55,7 +55,7 @@ To make configuring the nodes easier, we will download the klever mainnet config
 To download the configuration files, just run the command below.
 
 ```bash
-    curl -k https://backup.mainnet.klever.finance/config.mainnet.108.tar.gz \
+    curl -k https://backup.mainnet.klever.org/config.mainnet.108.tar.gz \
         | tar -xz -C .
 ```
 

--- a/src/app/delegation/page.mdx
+++ b/src/app/delegation/page.mdx
@@ -19,7 +19,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account delegate \
     klv186vg5k3pqetmfuy04620htcvz3krugu7hqe4ukczdy48r222j78q9y8vm5 \
     --bucketID=db0748c562c413a68b21a75249e1b936339fc03513e0bf076d3850b7a81113d2
@@ -65,7 +65,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account undelegate \
     --bucketID=db0748c562c413a68b21a75249e1b936339fc03513e0bf076d3850b7a81113d2
 ```

--- a/src/app/exchange-integration/page.mdx
+++ b/src/app/exchange-integration/page.mdx
@@ -19,9 +19,9 @@ To interact with Klever's blockchain, reading, fetching and uploading data, we p
 
 There you can find their documentation pages:
 
-[KleverChain Proxy API](https://api.mainnet.klever.finance/swagger/index.html)
+[KleverChain Proxy API](https://api.mainnet.klever.org/swagger/index.html)
 
-[KleverChain Node API](https://node.mainnet.klever.finance/swagger/index.html)
+[KleverChain Node API](https://node.mainnet.klever.org/swagger/index.html)
 
 
 ### Custom integration
@@ -36,7 +36,7 @@ To create transactions, you can [use the endpoints directly](/api-and-sdk#web-sd
 
 **Read transactions**
 
-To read the recent transactions, you'll need to  [use transaction list endpoint](https://api.mainnet.klever.finance/swagger/index.html#/Transaction/get_v1_0_transaction_list),  and use the queries that are relevant for your search (Ex: filter by asset, date, receiver/sender address, etc.)
+To read the recent transactions, you'll need to  [use transaction list endpoint](https://api.mainnet.klever.org/swagger/index.html#/Transaction/get_v1_0_transaction_list),  and use the queries that are relevant for your search (Ex: filter by asset, date, receiver/sender address, etc.)
 
 
 ## Testing
@@ -52,13 +52,13 @@ The mainnet is where the application will be actually running, so it is recommen
 ### Testnet
 
 - Kleverscan Testnet: [https://testnet.kleverscan.org/](https://testnet.kleverscan.org/)
-- KleverChain Testnet Proxy API: [https://api.testnet.klever.finance/](https://api.testnet.klever.finance/)
-- KleverChain Testnet Node API: [https://node.testnet.klever.finance/](https://node.testnet.klever.finance/)
+- KleverChain Testnet Proxy API: [https://api.testnet.klever.org/](https://api.testnet.klever.org/)
+- KleverChain Testnet Node API: [https://node.testnet.klever.org/](https://node.testnet.klever.org/)
 
 ### Mainnet
 
 - Kleverscan Mainnet: [https://kleverscan.org/](https://kleverscan.org/)
-- KleverChain Mainnet Proxy API: [https://api.mainnet.klever.finance/](https://api.mainnet.klever.finance/)
-- KleverChain Mainnet Node API: [https://node.mainnet.klever.finance/](https://node.mainnet.klever.finance/)
+- KleverChain Mainnet Proxy API: [https://api.mainnet.klever.org/](https://api.mainnet.klever.org/)
+- KleverChain Mainnet Node API: [https://node.mainnet.klever.org/](https://node.mainnet.klever.org/)
 
 

--- a/src/app/node-operations/page.mdx
+++ b/src/app/node-operations/page.mdx
@@ -116,7 +116,7 @@ Download latest config file and extract into your config directory
 _For MainNet_
 
 ```bash
-curl -k https://backup.mainnet.klever.finance/config.mainnet.108.tar.gz \
+curl -k https://backup.mainnet.klever.org/config.mainnet.108.tar.gz \
     | tar -xz -C ./node
 ```
 
@@ -205,14 +205,14 @@ You can speed up your node's first synchronization by using the FullNode databas
 _For MainNet_
 
 ```bash
-curl -k https://backup.mainnet.klever.finance/kleverchain.mainnet.latest.tar.gz \
+curl -k https://backup.mainnet.klever.org/kleverchain.mainnet.latest.tar.gz \
     | tar -xz -C ./node
 ```
 
 _For TestNet_
 
 ```bash
-curl -k https://backup.testnet.klever.finance/kleverchain.testnet.latest.tar.gz   | tar -xz -C ./node
+curl -k https://backup.testnet.klever.org/kleverchain.testnet.latest.tar.gz   | tar -xz -C ./node
 ```
 
 You can also opt for using fast sync with `--start-in-epoch` flag. This will indicate node to download last epoch only and start sync from there.
@@ -345,7 +345,7 @@ To use your wallet with Klever Toolchain, you will need to map your wallet priva
 
 Or if you are using a self-hosted node, use `--network=host` to access the local node API. You can also use a public node by adding an environment variable into the toolchain:
 
-`-e KLEVR_NODE=`https://`node.mainnet.klever.finance`
+`-e KLEVR_NODE=`https://`node.mainnet.klever.org`
 
 Send tokens with the following code:
 
@@ -356,7 +356,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account send klv1h7vx629mwuv4pnecn0k9clxp9rt7rquat3kvydgu8npt20e0ntjq3jhd40 137
 ```
 
@@ -379,7 +379,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account send klv1h7vx629mwuv4pnecn0k9clxp9rt7rquat3kvydgu8npt20e0ntjq3jhd40 \
     137 --kda=KFI
 ```
@@ -402,7 +402,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     [command] [arguments] --[flags]
 ```
 
@@ -433,7 +433,7 @@ operator [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -480,7 +480,7 @@ operator account [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -534,7 +534,7 @@ operator account address [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -572,7 +572,7 @@ operator account allowance <kdaID> [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -610,7 +610,7 @@ operator account balance <address> [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -650,7 +650,7 @@ operator account batchsend [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -689,7 +689,7 @@ operator account claim [CLAIM_TYPE] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -727,7 +727,7 @@ operator account create [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -765,7 +765,7 @@ operator account csv FILENAME [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -804,7 +804,7 @@ operator account delegate [TO] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -842,7 +842,7 @@ operator account export-sk [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -880,7 +880,7 @@ operator account export-sk [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -919,7 +919,7 @@ operator account freeze [AMOUNT] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -958,7 +958,7 @@ operator account import-sk [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -996,7 +996,7 @@ operator account info <address> [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1035,7 +1035,7 @@ operator account permission [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1074,7 +1074,7 @@ operator account send [TO] [AMOUNT] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1112,7 +1112,7 @@ operator account set-name [NAME] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1151,7 +1151,7 @@ operator account undelegate [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1191,7 +1191,7 @@ operator account unfreeze [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1230,7 +1230,7 @@ operator account withdraw [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1268,7 +1268,7 @@ operator account [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1324,7 +1324,7 @@ operator broadcast [Transaction] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1361,7 +1361,7 @@ operator fb [Address/TXHASH] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1402,7 +1402,7 @@ operator gov create-proposal [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1440,7 +1440,7 @@ operator gov vote [PROPOSAL_ID] [VOTE_AMOUNT] [VOTE_TYPE] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1478,7 +1478,7 @@ operator gov [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1523,7 +1523,7 @@ operator kapps buy [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1561,7 +1561,7 @@ operator kapps cancel-market [MARKET_ID] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1611,7 +1611,7 @@ operator kapps config-ito [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1653,7 +1653,7 @@ operator kapps config-marketplace [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1694,7 +1694,7 @@ operator kapps create-marketplace [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1739,7 +1739,7 @@ operator kapps sell [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1779,7 +1779,7 @@ operator kapps set-ito-prices [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1829,7 +1829,7 @@ operator kapps trigger-ito [TRIGGER_TYPE] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1867,7 +1867,7 @@ operator kapps [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1946,7 +1946,7 @@ operator kda create [KDA_TYPE] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -1987,7 +1987,7 @@ operator kda deposit [amount] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2044,7 +2044,7 @@ operator kda trigger [TRIGGER_TYPE] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2084,7 +2084,7 @@ operator kda withdraw [amount] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2122,7 +2122,7 @@ operator kda [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2164,7 +2164,7 @@ operator sign [Transaction] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2202,7 +2202,7 @@ operator tx-by-id [HASH] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2248,7 +2248,7 @@ operator validator config [OWNER_ADDRESS] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2294,7 +2294,7 @@ operator validator create [OWNER_ADDRESS] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2332,7 +2332,7 @@ operator validator unjail [OWNER_ADDRESS] [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2370,7 +2370,7 @@ operator validator [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password
@@ -2411,7 +2411,7 @@ operator version [flags]
   -k, --key-file string           set walelt pem file --key-file=./walletKey.pem (default "./walletKey.pem")
       --message stringArray       set TX message --message="MyMessage"
   -m, --multi-files stringArray   add more files to sign tx. Ex: -m=./file.pem -m=./file2.pem
-  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.finance (default "http://localhost:8080")
+  -n, --node string               entrypoint to node API --node=http://node.testnet.klever.org (default "http://localhost:8080")
       --nonce uint                set TX nonce --nonce=33
   -p, --password string[="*"]     --password=MY_SECRET
       --password-file string      path to a file containing the password

--- a/src/app/node.js/page.mdx
+++ b/src/app/node.js/page.mdx
@@ -82,8 +82,8 @@ The default network is the Kleverchain Mainnet, but if you want to use the Kleve
 import { utils, IProvider } from "@klever/sdk-node";
 ...
   const provider: IProvider = {
-    api: "https://api.testnet.klever.finance",
-    node: "https://node.testnet.klever.finance",
+    api: "https://api.testnet.klever.org",
+    node: "https://node.testnet.klever.org",
   };
 
   utils.setProviders(provider);
@@ -190,8 +190,8 @@ Each Update Metadata has a Kapp Fee of 2KLV, and the Bandwidth Fee depends on th
 import { Account, utils, TransactionType } from '@klever/sdk-node'
 
 utils.setProviders({
-  api: 'https://api.devnet.klever.finance',
-  node: 'https://node.devnet.klever.finance',
+  api: 'https://api.devnet.klever.org',
+  node: 'https://node.devnet.klever.org',
 })
 
 const privateKey = 'Your PrivateKey'

--- a/src/app/staking/page.mdx
+++ b/src/app/staking/page.mdx
@@ -42,7 +42,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance account freeze 10000000
+    --node=https://node.mainnet.klever.org account freeze 10000000
 ```
 
 After the "freeze" instruction, there is this structure: [AMOUNT].
@@ -66,7 +66,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account unfreeze --bucketID=1acd6f3958f24a058e5c185fe1491bb3b42c88f65a085d9b4dbfd5866273481c
 ```
 
@@ -85,7 +85,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account withdraw
 ```
 
@@ -101,7 +101,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account claim 0 --id=KLV
 ```
 
@@ -133,7 +133,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \\
     --entrypoint=/usr/local/bin/operator \\
     kleverapp/klever-go:latest \\
     --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.finance \\
+    --node=https://node.mainnet.klever.org \\
     kda create 0 --canBurn=true --canMint=true --canFreeze=true --canPause=true --canWipe=true --logo=LOGO_URL --maxSupply=AMOUNT_MAX --precision=6 --name=KDA_NAME --ticker=KDA_TICKER —-interestType 1
 ```
 
@@ -150,7 +150,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \\
     --entrypoint=/usr/local/bin/operator \\
     kleverapp/klever-go:latest \\
     --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.finance \\
+    --node=https://node.mainnet.klever.org \\
     kda deposit AMOUNT --depositType=0 --kdaID=YOUR_KDA_ID --currencyID=KDA_YOU_WANT_TO_PAY_REWARDS
 ```
 
@@ -169,7 +169,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \\
     --entrypoint=/usr/local/bin/operator \\
     kleverapp/klever-go:latest \\
     --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.finance \\
+    --node=https://node.mainnet.klever.org \\
     account freeze AMOUNT --kda=KDA_id_YOU_WANT_TO_FREEZE
 ```
 
@@ -186,7 +186,7 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest \
     --key-file=./walletKey.pem \
-    --node=https://node.mainnet.klever.finance \
+    --node=https://node.mainnet.klever.org \
     account claim 0 --id=KDA_ID_YOU_HAVE_FROZEN
 ```
 

--- a/src/app/tutorials/crowdfunding/page.mdx
+++ b/src/app/tutorials/crowdfunding/page.mdx
@@ -525,9 +525,9 @@ fn main() {
 
    - Key File: The path to your .pem file that will be used to deploy the contract.
    - Address: The address (refered to .pem) that will be used to deploy the contract.
-   - Node: You can use https://node.testnet.klever.finance (Testnet) or https://node.mainnet.klever.finance (Mainnet).
+   - Node: You can use https://node.testnet.klever.org (Testnet) or https://node.mainnet.klever.org (Mainnet).
 
-3. To create your own .pem file, you can access the [KApps](https://kapps.klever.finance/connect) and click on the "Generate New Account" button.
+3. To create your own .pem file, you can access the [KApps](https://kapps.klever.org/connect) and click on the "Generate New Account" button.
 
    <img src="/tutorials-images/crowdfunding/generate.png" alt="generate" />
 
@@ -540,7 +540,7 @@ fn main() {
 6. If you are using the Tesnet you can ask for some Test KLV. Just run the following command on your terminal **Make sure to replace with your address**:
 
 ```bash
-curl -X POST https://api.testnet.klever.finance/v1.0/transaction/send-user-funds/klv1sr70jktl8rhq37s8htl390qm6mnx4wsdm5e8nykk797d6d3n85vsghyqd4
+curl -X POST https://api.testnet.klever.org/v1.0/transaction/send-user-funds/klv1sr70jktl8rhq37s8htl390qm6mnx4wsdm5e8nykk797d6d3n85vsghyqd4
 ```
 
 7. Now you can click on the Klever IDE Icon and Select the Crowdfunding, and with the rigth click, selec the option Build Contract.
@@ -584,7 +584,7 @@ Here we will show some examples of how to integrate the Crowdfunding contract wi
 
 ```javascript
 // setup constants
-const nodeUrl = 'https://node.testnet.klever.finance'
+const nodeUrl = 'https://node.testnet.klever.org'
 const scAddress = 'klv1qqqqqqqqqqqqqpgqak42rwftgzrd929g27jagf9dmh33a7hu0n0qzdr86f'
 
 // fetch the last crowdfunding view

--- a/src/app/web-app/page.mdx
+++ b/src/app/web-app/page.mdx
@@ -38,8 +38,8 @@ import {
 } from 'https://sdk.kleverscan.org/kleverchain-sdk-web-esm-1-0-x.js'
 
 const provider = {
-  api: 'https://api.testnet.klever.finance',
-  node: 'https://node.testnet.klever.finance',
+  api: 'https://api.testnet.klever.org',
+  node: 'https://node.testnet.klever.org',
 }
 
 web.setProvider(provider)
@@ -102,8 +102,8 @@ The following scripts are fully functional for a send button component that does
 import React from 'react'
 import { IProvider, web, ITransfer, TransactionType } from '@klever/sdk-web'
 const provider: IProvider = {
-  api: 'https://api.testnet.klever.finance',
-  node: 'https://node.testnet.klever.finance',
+  api: 'https://api.testnet.klever.org',
+  node: 'https://node.testnet.klever.org',
 }
 
 web.setProvider(provider)
@@ -189,8 +189,8 @@ Eg: Set it inside a group of Routes, Context, or in the application entry point.
 import { web, IProvider } from '@klever/sdk-web';
 ...
   const provider:IProvider = {
-      api: 'https://api.testnet.klever.finance',
-      node: 'https://node.testnet.klever.finance'
+      api: 'https://api.testnet.klever.org',
+      node: 'https://node.testnet.klever.org'
   };
 
   web.setProvider(provider);


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality