### PR TITLE
updated doc with correct chrome extension url

### DIFF
--- a/src/app/quickstart/page.mdx
+++ b/src/app/quickstart/page.mdx
@@ -12,7 +12,7 @@ This guide will get you all set up and ready to use Klever Wallet in your applic
   Before you can procced with this quickstart, make sure your Klever Wallet is
   properly installed and configured. If you haven't done so already, check out
   the [Klever Wallet
-  Installer](https://chrome.google.com/webstore/detail/klever-wallet/lmbifcmbofehdpolpdpnlcnanolnlkec).
+  Installer](https://chromewebstore.google.com/detail/klever-wallet/ifclboecfhkjbpmhgehodcjpciihhmif).
 </Note>
 
 ## Verify installation


### PR DESCRIPTION
Updated the Klever wallet chrome extension url from [Old](https://chrome.google.com/webstore/detail/klever-wallet/lmbifcmbofehdpolpdpnlcnanolnlkec) to [New](https://chromewebstore.google.com/detail/klever-wallet/ifclboecfhkjbpmhgehodcjpciihhmif). 

Wallet extension is not available at the old url:
<img width="3590" height="2166" alt="Screenshot 2025-08-29 at 12 13 50 PM" src="https://github.com/user-attachments/assets/1e6a39c7-7c43-441f-a606-2dadf3f15653" />


This PR should be merged as it will improve developer experience and ease of access.