### PR TITLE
Update klever wallet-extension and icons url in docs

### DIFF
--- a/src/app/quickstart/page.mdx
+++ b/src/app/quickstart/page.mdx
@@ -12,7 +12,7 @@ This guide will get you all set up and ready to use Klever Wallet in your applic
   Before you can procced with this quickstart, make sure your Klever Wallet is
   properly installed and configured. If you haven't done so already, check out
   the [Klever Wallet
-  Installer](https://chrome.google.com/webstore/detail/klever-wallet/lmbifcmbofehdpolpdpnlcnanolnlkec).
+  Installer](https://chromewebstore.google.com/detail/klever-wallet/ifclboecfhkjbpmhgehodcjpciihhmif).
 </Note>
 
 ## Verify installation

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -141,9 +141,6 @@ function SmallPrint() {
         <SocialLink href="https://forum.klever.org" icon={KleverLogo}>
           Join our Forum
         </SocialLink>
-        {/* <SocialLink href="#" icon={DiscordIcon}>
-          Join our Discord server
-        </SocialLink> */}
       </div>
     </div>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,6 +6,8 @@ import { usePathname } from 'next/navigation'
 import { Button } from '@/components/Button'
 import { findActivePageRecursive } from '@/components/Navigation'
 import { navigation } from '@/consts/navigation'
+import { Logo } from './Logo'
+import { KleverLogo } from './KleverLogo'
 
 function PageLink({
   label,
@@ -87,6 +89,8 @@ function TwitterIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   )
 }
 
+
+
 function GitHubIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (
     <svg viewBox="0 0 20 20" aria-hidden="true" {...props}>
@@ -131,15 +135,15 @@ function SmallPrint() {
         &copy; Copyright {new Date().getFullYear()}. All rights reserved.
       </p>
       <div className="flex gap-4">
-        <SocialLink href="#" icon={TwitterIcon}>
+        <SocialLink href="https://x.com/klever_org" icon={TwitterIcon}>
           Follow us on Twitter
         </SocialLink>
-        <SocialLink href="#" icon={GitHubIcon}>
-          Follow us on GitHub
+        <SocialLink href="https://forum.klever.org" icon={KleverLogo}>
+          Join our Forum
         </SocialLink>
-        <SocialLink href="#" icon={DiscordIcon}>
+        {/* <SocialLink href="#" icon={DiscordIcon}>
           Join our Discord server
-        </SocialLink>
+        </SocialLink> */}
       </div>
     </div>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -234,13 +234,14 @@ export const Header = forwardRef<
       <div className="flex items-center gap-5">
         <nav className="hidden md:block">
           <ul role="list" className="flex items-center gap-8">
-            <TopLevelNavItem
-              href="https://docs.klever.org/api-and-sdk"
-            >
+            <TopLevelNavItem href="https://docs.klever.org/api-and-sdk">
               API
             </TopLevelNavItem>
             <TopLevelNavItem href="#">Documentation</TopLevelNavItem>
             <TopLevelNavItem href="https://forum.klever.org/">
+              Forum
+            </TopLevelNavItem>
+            <TopLevelNavItem href="https://support.klever.org/">
               Support
             </TopLevelNavItem>
           </ul>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -234,9 +234,15 @@ export const Header = forwardRef<
       <div className="flex items-center gap-5">
         <nav className="hidden md:block">
           <ul role="list" className="flex items-center gap-8">
-            <TopLevelNavItem href="/">API</TopLevelNavItem>
+            <TopLevelNavItem
+              href="https://docs.klever.org/api-and-sdk"
+            >
+              API
+            </TopLevelNavItem>
             <TopLevelNavItem href="#">Documentation</TopLevelNavItem>
-            <TopLevelNavItem href="#">Support</TopLevelNavItem>
+            <TopLevelNavItem href="https://forum.klever.org/">
+              Support
+            </TopLevelNavItem>
           </ul>
         </nav>
         <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" />

--- a/src/components/KleverLogo.tsx
+++ b/src/components/KleverLogo.tsx
@@ -1,0 +1,54 @@
+export function KleverLogo(props: React.ComponentPropsWithoutRef<'svg'>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path
+        d="M23.6552 23.5585H14L23.6552 13.9999V23.5585Z"
+        
+      />
+      <path
+        opacity="0.14"
+        d="M23.6552 23.5585L18.8276 18.7309L19.6966 17.9585L23.6552 23.5585Z"
+
+      />
+      <path
+        d="M23.6552 23.5585H4.44141V4.34473L23.6552 23.5585Z"
+
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_568_2519"
+          x1="18.8276"
+          y1="13.9556"
+          x2="18.8276"
+          y2="23.5777"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="2.71717e-07" stopColor="#FF4681" />
+          <stop offset="1" stopColor="#9B44F6" />
+        </linearGradient>
+        <linearGradient
+          id="paint1_linear_568_2519"
+          x1="21.1564"
+          y1="18.5887"
+          x2="19.802"
+          y2="22.1648"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="9.43019e-07" />
+          <stop offset="1" />
+        </linearGradient>
+        <linearGradient
+          id="paint2_linear_568_2519"
+          x1="-0.135918"
+          y1="9.3743"
+          x2="19.1083"
+          y2="28.6185"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="9.43019e-07" stopColor="#FF4681" />
+          <stop offset="0.7392" stopColor="#9B44F6" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}


### PR DESCRIPTION
## 1. Wallet Extension Link Update

- Updated wallet extension url to the correct link. Old url doesn't work anymore.
<img width="1693" height="1192" alt="image" src="https://github.com/user-attachments/assets/c01a77b6-9b6e-4aee-a864-5ddda9b7eab3" />


## 2. External/Social Links Update (X and Forum)

- Modified external links in the documentation footer to open/route correctly.

## 3. Component Separation

- Created a new `KleverLogo.tsx` component that extracts only the logo mark from the full logo
- Provides a clean, reusable logo component that can be used independently from the text logo
- Component accepts the same props interface as other SVG components in the system

## Usage of KleverLogo Component

```tsx
import { KleverLogo } from './components/KleverLogo'

// Example usage
;<KleverLogo className="h-6 w-6" />
```

This separation allows for more flexible usage of the logo throughout the documentation site, especially in places where only the icon may be needed without the accompanying text.

This PR should be merged because the updates will ensure better developer experience, developers can easily find Klever forum, x, wallet etc.
