### PR TITLE
[KLC-1823] Update docker run commands folder permissions

### DIFF
--- a/src/app/about-our-technology/page.mdx
+++ b/src/app/about-our-technology/page.mdx
@@ -151,7 +151,8 @@ Use the `Asset Trigger` Contract, with the `UpdateKDAFeePool` Trigger, to activa
 Optional: create a routine that does this periodically, updating the price based on the desired ratio conversion of your KDA and the KLV one for example.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -166,7 +167,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 Use the `Deposit` Contract, with `depositType 1` to deposit KLV in the KDA Fee Pool, this is where the blockchain will get the fees payed from, while you buy back your asset from circulation, reducing inflation.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -271,7 +273,8 @@ KFI holders will be able to vote for the following topics:
 To create an asset in Klever Blockchain use the follow command, ch
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/account-permissions/page.mdx
+++ b/src/app/account-permissions/page.mdx
@@ -132,7 +132,8 @@ Finally, it's worth noting that PermID is passed when creating the transaction b
 For you to create the permissions of your account it is necessary to carry out an UpdateAccountPermission transaction
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -145,7 +146,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 Instead of putting **your-permission-here**, you should put your permissions based on the permission data shown above.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/become-a-validator/page.mdx
+++ b/src/app/become-a-validator/page.mdx
@@ -9,7 +9,8 @@ To become a Klever Validator Node you will need 10M KLV staked, from that, at le
 Registering a validator is done in this way:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -51,7 +52,8 @@ where:
 In order to freeze KLV, you should type the following code:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -74,7 +76,8 @@ The minimum amount allowed to stake KLV is 1000 KLV.
 Delegate to an address [TO], pointing to the bucket [BUCKET_ID] where the frozen KLV is located.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -99,7 +102,8 @@ It's important to know that there's a minimum self-staking amount for the valida
 WIth the operator CLI, you can check the bucket ID with the command `tx-by-id` followed by the hash of the freeze transaction:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -119,7 +123,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 You can change the validator configuration using this command:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/create-local-testnet/page.mdx
+++ b/src/app/create-local-testnet/page.mdx
@@ -15,8 +15,8 @@ For this tutorial the default will be 2 validators.
 To generate the necessary keys you will need to execute the command below. If you want to generate a different number of validator nodes, just change the value in **--num-keys=2**
 
 ```bash
+    chown -R 999 .
     docker run -it --rm -v $(pwd):/opt/klever-blockchain \
-        --user "$(id -u):$(id -g)" \
         --entrypoint='' kleverapp/klever-go:latest keygenerator --num-keys=2 --key-type=both
 ```
 

--- a/src/app/delegation/page.mdx
+++ b/src/app/delegation/page.mdx
@@ -13,7 +13,8 @@ Delegate to other validators
 Delegate to an address [TO], pointing to the bucket [BUCKET_ID] where the frozen KLV is located.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -36,7 +37,8 @@ It's important to know that there's a minimum self-staking amount for the valida
 WIth the operator CLI, you can check the bucket ID with the command `tx-by-id` followed by the hash of the freeze transaction:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -59,7 +61,8 @@ Undelegate
 To undelegate, you just need to specify the Bucket ID:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/node-operations/page.mdx
+++ b/src/app/node-operations/page.mdx
@@ -68,7 +68,8 @@ mkdir wallet
 ```
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest account create
@@ -83,7 +84,8 @@ If the output directory does not exist, it will be created but you may run into 
 To check your wallet certificate and address, type:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest account address
@@ -132,8 +134,8 @@ curl -k https://backup.testnet.klever.org/config.testnet.109.tar.gz \
 Execute a command inside the docker container to create wallets for validators. The data is then forwarded to the directory created previously.
 
 ```bash
+chown -R 999 .
 docker run -it --rm -v $(pwd)/node/config:/opt/klever-blockchain \
-    --user "$(id -u):$(id -g)" \
     --entrypoint='' kleverapp/klever-go:latest keygenerator
 ```
 
@@ -144,8 +146,8 @@ The command for running a node comes with a few settings: it includes mappings f
 _MainNet_
 
 ```bash
+chown -R 999 .
 docker run -it --rm \
-    --user "$(id -u):$(id -g)" \
     --name klever-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -182,8 +184,8 @@ When you are done setting up and running your node, you are expected to see info
 When running in the background, add parameter `--use-log-view` and replace `--rm` for `-d`
 
 ```bash
+chown -R 999 .
 docker run -it -d --restart unless-stopped \
-    --user "$(id -u):$(id -g)" \
     --name klever-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -255,8 +257,8 @@ mkdir -p $(pwd)/node/config $(pwd)/node/db $(pwd)/node/logs
 Execute a command inside the docker container to create wallets for validators. The data is then forwarded to the directory created previously.
 
 ```bash
+chown -R 999 .
 docker run -it --rm -v $(pwd)/node:/opt/klever-blockchain \
-    --user "$(id -u):$(id -g)" \
     --entrypoint='' kleverapp/klever-go:latest keygenerator
 ```
 
@@ -265,8 +267,8 @@ docker run -it --rm -v $(pwd)/node:/opt/klever-blockchain \
 The command for running a node comes with a few settings: it includes mappings for cryptographic keys, data directories and logs, as well as network ports, the application that will run when the docker image is executed and the file of node validators signature.
 
 ```bash
+chown -R 999 .
 docker run -it --rm \
-    --user "$(id -u):$(id -g)" \
     --name klever-node \
     -v $(pwd)/node/confgi:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -542,8 +544,8 @@ preferences:
 Use the same docker command as a regular node, but ensure your `config.yaml` file has the correct `redundancyLevel`:
 
 ```bash
+chown -R 999 .
 docker run -it --rm \
-    --user "$(id -u):$(id -g)" \
     --name klever-fallback-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -582,7 +584,8 @@ Or if you are using a self-hosted node, use `--network=host` to access the local
 Send tokens with the following code:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -605,7 +608,8 @@ If no `--kda` is passed, as in the example above, the default KDA is KLV.
 Here is another example, sending KFI:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -662,7 +666,8 @@ operator [command] [arguments] --[flags]
 If you are using the docker image operator, use the generic command version:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/smart-contracts/reference/upgrading/page.mdx
+++ b/src/app/smart-contracts/reference/upgrading/page.mdx
@@ -3,15 +3,16 @@
 Upgrading a smart contract is quite simple, although the effects might not be very clear. Just run this command to upgrade it:
 
 ```
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd):/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest  --key-file=KEY_FILE \
-    cc upgrade SC_ADDRESS --wasm=WASM_PATH \
-    --vmType=0500 --arguments example --payable --payableBySC --readable --upgradeable
+    sc upgrade SC_ADDRESS --wasm=WASM_PATH \
+     --args example --payable --payableBySC --readable --upgradeable
 ```
 
-Replace SC_ADDRESS, KEY_FILE and WASM_PATH accordingly. If needs arguments, add --arguments VALUE.
+Replace SC_ADDRESS, KEY_FILE and WASM_PATH accordingly. If needs arguments, add --args VALUE.
 
 Check your flags --payable --payableBySC --readable --upgradeable to make sure they are correct.

--- a/src/app/staking/page.mdx
+++ b/src/app/staking/page.mdx
@@ -36,7 +36,8 @@ This means that the owner of the KDA with FPR will be responsible to their staki
 In order to freeze KLV, you should type the following code:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -60,7 +61,8 @@ The minimum amount allowed to stake KLV is 1000 KLV.
 To unfreeze assets, you need to run the follwoing command, signaling the bucket ID, which was generated when you first staked those assets:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -79,7 +81,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 Withdrawing assets will remove the values of all the unfrozen buckets automatically. This is how you should do it:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -95,7 +98,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 You can claim rewards either from Staking (with no delegation) or Allowance (from delegation):
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -127,13 +131,14 @@ First of all, you need to create a KDA. Use the Create Asset Contract to create 
 PS: You can not upgrade an existing KDA from APR to FPR Support.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \\
-    -v $(pwd)/wallet:/opt/klever-blockchain \\
-    --network=host \\
-    --entrypoint=/usr/local/bin/operator \\
-    kleverapp/klever-go:latest \\
-    --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.org \\
+chown -R 999 .
+docker run -it --rm \
+    -v $(pwd)/wallet:/opt/klever-blockchain \
+    --network=host \
+    --entrypoint=/usr/local/bin/operator \
+    kleverapp/klever-go:latest \
+    --key-file=./walletKey.pem \
+    --node=https://node.mainnet.klever.org \
     kda create 0 --canBurn=true --canMint=true --canFreeze=true --canPause=true --canWipe=true --logo=LOGO_URL --maxSupply=AMOUNT_MAX --precision=6 --name=KDA_NAME --ticker=KDA_TICKER —-interestType 1
 ```
 
@@ -144,13 +149,14 @@ After you created or updated your KDA, you need to deposit KDA to your FPR pool 
 PS: you can deposit multiple KDAs to your FPR pool to pay rewards with them.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \\
-    -v $(pwd)/wallet:/opt/klever-blockchain \\
-    --network=host \\
-    --entrypoint=/usr/local/bin/operator \\
-    kleverapp/klever-go:latest \\
-    --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.org \\
+chown -R 999 .
+docker run -it --rm \
+    -v $(pwd)/wallet:/opt/klever-blockchain \
+    --network=host \
+    --entrypoint=/usr/local/bin/operator \
+    kleverapp/klever-go:latest \
+    --key-file=./walletKey.pem \
+    --node=https://node.mainnet.klever.org \
     kda deposit AMOUNT --depositType=0 --kdaID=YOUR_KDA_ID --currencyID=KDA_YOU_WANT_TO_PAY_REWARDS
 ```
 
@@ -163,13 +169,14 @@ If you are a holder and want to receive rewards.
 To be able to receive rewards of a KDA with FPR you need to freeze this KDA with the following command. Make sure the asset you’re freezing supports FPR.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \\
-    -v $(pwd)/wallet:/opt/klever-blockchain \\
-    --network=host \\
-    --entrypoint=/usr/local/bin/operator \\
-    kleverapp/klever-go:latest \\
-    --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.org \\
+chown -R 999 .
+docker run -it --rm \
+    -v $(pwd)/wallet:/opt/klever-blockchain \
+    --network=host \
+    --entrypoint=/usr/local/bin/operator \
+    kleverapp/klever-go:latest \
+    --key-file=./walletKey.pem \
+    --node=https://node.mainnet.klever.org \
     account freeze AMOUNT --kda=KDA_id_YOU_WANT_TO_FREEZE
 ```
 
@@ -180,7 +187,8 @@ After the reward is generated, you can claim it with the following command:
 PS: You need to claim your rewards at least 100 epochs after the reward is generated.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \


### PR DESCRIPTION
This pull request updates the documentation for running Klever Blockchain commands in various `.mdx` files. The main change is the removal of the `--user "$(id -u):$(id -g)"` flag from all `docker run` command examples and the addition of a preceding `chown -R 999 .` command. This simplifies Docker usage instructions and ensures proper file permissions for the blockchain data directories. Additionally, there are minor corrections to smart contract upgrade command syntax.

**Docker Command Updates**

* All `docker run` examples in documentation files now omit the `--user "$(id -u):$(id -g)"` flag and instead instruct users to run `chown -R 999 .` before the Docker command to set correct permissions for the blockchain directories. (`src/app/about-our-technology/page.mdx`, `src/app/account-permissions/page.mdx`, `src/app/become-a-validator/page.mdx`, `src/app/delegation/page.mdx`, `src/app/node-operations/page.mdx`, `src/app/staking/page.mdx`, `src/app/create-local-testnet/page.mdx`, [[1]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfL154-R155) [[2]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfL169-R171) [[3]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfL274-R277) [[4]](diffhunk://#diff-414f502e15c5099796d2d25f06e86c236b4dc1ff644bf5703d5f57110d6cfd39L135-R136) [[5]](diffhunk://#diff-414f502e15c5099796d2d25f06e86c236b4dc1ff644bf5703d5f57110d6cfd39L148-R150) [[6]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL12-R13) [[7]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL54-R56) [[8]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL77-R80) [[9]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL102-R106) [[10]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL122-R127) [[11]](diffhunk://#diff-caec9d079a08b9f00077aa1601d7cafee5a4702834d4668671eab7aa8f05b405R18-L19) [[12]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380L16-R17) [[13]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380L39-R41) [[14]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380L62-R65) [[15]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL71-R72) [[16]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL86-R88) [[17]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR137-L136) [[18]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR149-L148) [[19]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR187-L186) [[20]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR260-L259) [[21]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR270-L269) [[22]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR547-L546) [[23]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL585-R588) [[24]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL608-R612) [[25]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL665-R670) [[26]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L39-R40) [[27]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L63-R65) [[28]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L82-R85) [[29]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L98-R102) [[30]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L130-R141) [[31]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L147-R159)

**Smart Contract Command Syntax Corrections**

* The smart contract upgrade command now uses `sc upgrade` instead of `cc upgrade`, and argument flags are corrected to use `--args` instead of `--arguments`. The documentation also clarifies usage of these flags. (`src/app/smart-contracts/reference/upgrading/page.mdx`, [src/app/smart-contracts/reference/upgrading/page.mdxL6-R16](diffhunk://#diff-36f167fadeb6663afb6a436018864c8622066dacd50365fd15fee21a621e99dcL6-R16))

These changes make the documentation clearer and ensure users set up their environments with the correct permissions, reducing potential errors when running Klever Blockchain commands in Docker containers.