### PR TITLE
Add instructions for chown on newer Docker versions

### DIFF
--- a/src/app/about-our-technology/page.mdx
+++ b/src/app/about-our-technology/page.mdx
@@ -151,7 +151,8 @@ Use the `Asset Trigger` Contract, with the `UpdateKDAFeePool` Trigger, to activa
 Optional: create a routine that does this periodically, updating the price based on the desired ratio conversion of your KDA and the KLV one for example.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -166,7 +167,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 Use the `Deposit` Contract, with `depositType 1` to deposit KLV in the KDA Fee Pool, this is where the blockchain will get the fees payed from, while you buy back your asset from circulation, reducing inflation.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -271,7 +273,8 @@ KFI holders will be able to vote for the following topics:
 To create an asset in Klever Blockchain use the follow command, ch
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/about-our-technology/page.mdx
+++ b/src/app/about-our-technology/page.mdx
@@ -150,8 +150,10 @@ Use the `Asset Trigger` Contract, with the `UpdateKDAFeePool` Trigger, to activa
 
 Optional: create a routine that does this periodically, updating the price based on the desired ratio conversion of your KDA and the KLV one for example.
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -167,7 +169,6 @@ docker run -it --rm \
 Use the `Deposit` Contract, with `depositType 1` to deposit KLV in the KDA Fee Pool, this is where the blockchain will get the fees payed from, while you buy back your asset from circulation, reducing inflation.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -272,8 +273,11 @@ KFI holders will be able to vote for the following topics:
 
 To create an asset in Klever Blockchain use the follow command, ch
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
+
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \

--- a/src/app/account-permissions/page.mdx
+++ b/src/app/account-permissions/page.mdx
@@ -131,8 +131,10 @@ Finally, it's worth noting that PermID is passed when creating the transaction b
 
 For you to create the permissions of your account it is necessary to carry out an UpdateAccountPermission transaction
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -146,7 +148,6 @@ docker run -it --rm \
 Instead of putting **your-permission-here**, you should put your permissions based on the permission data shown above.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \

--- a/src/app/account-permissions/page.mdx
+++ b/src/app/account-permissions/page.mdx
@@ -132,7 +132,8 @@ Finally, it's worth noting that PermID is passed when creating the transaction b
 For you to create the permissions of your account it is necessary to carry out an UpdateAccountPermission transaction
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -145,7 +146,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 Instead of putting **your-permission-here**, you should put your permissions based on the permission data shown above.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/become-a-validator/page.mdx
+++ b/src/app/become-a-validator/page.mdx
@@ -9,7 +9,8 @@ To become a Klever Validator Node you will need 10M KLV staked, from that, at le
 Registering a validator is done in this way:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -51,7 +52,8 @@ where:
 In order to freeze KLV, you should type the following code:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -74,7 +76,8 @@ The minimum amount allowed to stake KLV is 1000 KLV.
 Delegate to an address [TO], pointing to the bucket [BUCKET_ID] where the frozen KLV is located.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -99,7 +102,8 @@ It's important to know that there's a minimum self-staking amount for the valida
 WIth the operator CLI, you can check the bucket ID with the command `tx-by-id` followed by the hash of the freeze transaction:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -119,7 +123,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 You can change the validator configuration using this command:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/become-a-validator/page.mdx
+++ b/src/app/become-a-validator/page.mdx
@@ -8,8 +8,10 @@ To become a Klever Validator Node you will need 10M KLV staked, from that, at le
 
 Registering a validator is done in this way:
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -52,7 +54,6 @@ where:
 In order to freeze KLV, you should type the following code:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -76,7 +77,6 @@ The minimum amount allowed to stake KLV is 1000 KLV.
 Delegate to an address [TO], pointing to the bucket [BUCKET_ID] where the frozen KLV is located.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -102,7 +102,6 @@ It's important to know that there's a minimum self-staking amount for the valida
 WIth the operator CLI, you can check the bucket ID with the command `tx-by-id` followed by the hash of the freeze transaction:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -123,7 +122,6 @@ docker run -it --rm \
 You can change the validator configuration using this command:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \

--- a/src/app/create-local-testnet/page.mdx
+++ b/src/app/create-local-testnet/page.mdx
@@ -15,8 +15,8 @@ For this tutorial the default will be 2 validators.
 To generate the necessary keys you will need to execute the command below. If you want to generate a different number of validator nodes, just change the value in **--num-keys=2**
 
 ```bash
+    chown -R 999 .
     docker run -it --rm -v $(pwd):/opt/klever-blockchain \
-        --user "$(id -u):$(id -g)" \
         --entrypoint='' kleverapp/klever-go:latest keygenerator --num-keys=2 --key-type=both
 ```
 

--- a/src/app/create-local-testnet/page.mdx
+++ b/src/app/create-local-testnet/page.mdx
@@ -14,8 +14,10 @@ For this tutorial the default will be 2 validators.
 
 To generate the necessary keys you will need to execute the command below. If you want to generate a different number of validator nodes, just change the value in **--num-keys=2**
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```bash
-    chown -R 999 .
     docker run -it --rm -v $(pwd):/opt/klever-blockchain \
         --entrypoint='' kleverapp/klever-go:latest keygenerator --num-keys=2 --key-type=both
 ```

--- a/src/app/delegation/page.mdx
+++ b/src/app/delegation/page.mdx
@@ -13,7 +13,8 @@ Delegate to other validators
 Delegate to an address [TO], pointing to the bucket [BUCKET_ID] where the frozen KLV is located.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -36,7 +37,8 @@ It's important to know that there's a minimum self-staking amount for the valida
 WIth the operator CLI, you can check the bucket ID with the command `tx-by-id` followed by the hash of the freeze transaction:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -59,7 +61,8 @@ Undelegate
 To undelegate, you just need to specify the Bucket ID:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/delegation/page.mdx
+++ b/src/app/delegation/page.mdx
@@ -12,8 +12,10 @@ Delegate to other validators
 
 Delegate to an address [TO], pointing to the bucket [BUCKET_ID] where the frozen KLV is located.
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -37,7 +39,6 @@ It's important to know that there's a minimum self-staking amount for the valida
 WIth the operator CLI, you can check the bucket ID with the command `tx-by-id` followed by the hash of the freeze transaction:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -61,7 +62,6 @@ Undelegate
 To undelegate, you just need to specify the Bucket ID:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \

--- a/src/app/node-operations/page.mdx
+++ b/src/app/node-operations/page.mdx
@@ -59,6 +59,10 @@ To download Klever Toolchain, type:
 docker pull kleverapp/klever-go:latest
 ```
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
+
 ## How To Create A Wallet
 
 To create a wallet, choosing the output folder, first create the output folder and then run the operator with `create-wallet` command:
@@ -68,7 +72,6 @@ mkdir wallet
 ```
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --entrypoint=/usr/local/bin/operator \
@@ -84,7 +87,6 @@ If the output directory does not exist, it will be created but you may run into 
 To check your wallet certificate and address, type:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --entrypoint=/usr/local/bin/operator \
@@ -134,7 +136,6 @@ curl -k https://backup.testnet.klever.org/config.testnet.109.tar.gz \
 Execute a command inside the docker container to create wallets for validators. The data is then forwarded to the directory created previously.
 
 ```bash
-chown -R 999 .
 docker run -it --rm -v $(pwd)/node/config:/opt/klever-blockchain \
     --entrypoint='' kleverapp/klever-go:latest keygenerator
 ```
@@ -146,7 +147,6 @@ The command for running a node comes with a few settings: it includes mappings f
 _MainNet_
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     --name klever-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
@@ -184,7 +184,6 @@ When you are done setting up and running your node, you are expected to see info
 When running in the background, add parameter `--use-log-view` and replace `--rm` for `-d`
 
 ```bash
-chown -R 999 .
 docker run -it -d --restart unless-stopped \
     --name klever-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
@@ -257,7 +256,6 @@ mkdir -p $(pwd)/node/config $(pwd)/node/db $(pwd)/node/logs
 Execute a command inside the docker container to create wallets for validators. The data is then forwarded to the directory created previously.
 
 ```bash
-chown -R 999 .
 docker run -it --rm -v $(pwd)/node:/opt/klever-blockchain \
     --entrypoint='' kleverapp/klever-go:latest keygenerator
 ```
@@ -267,7 +265,6 @@ docker run -it --rm -v $(pwd)/node:/opt/klever-blockchain \
 The command for running a node comes with a few settings: it includes mappings for cryptographic keys, data directories and logs, as well as network ports, the application that will run when the docker image is executed and the file of node validators signature.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     --name klever-node \
     -v $(pwd)/node/confgi:/opt/klever-blockchain/config/node \
@@ -544,7 +541,6 @@ preferences:
 Use the same docker command as a regular node, but ensure your `config.yaml` file has the correct `redundancyLevel`:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     --name klever-fallback-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
@@ -584,7 +580,6 @@ Or if you are using a self-hosted node, use `--network=host` to access the local
 Send tokens with the following code:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -608,7 +603,6 @@ If no `--kda` is passed, as in the example above, the default KDA is KLV.
 Here is another example, sending KFI:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -666,7 +660,6 @@ operator [command] [arguments] --[flags]
 If you are using the docker image operator, use the generic command version:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \

--- a/src/app/node-operations/page.mdx
+++ b/src/app/node-operations/page.mdx
@@ -68,7 +68,8 @@ mkdir wallet
 ```
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest account create
@@ -83,7 +84,8 @@ If the output directory does not exist, it will be created but you may run into 
 To check your wallet certificate and address, type:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest account address
@@ -132,8 +134,8 @@ curl -k https://backup.testnet.klever.org/config.testnet.109.tar.gz \
 Execute a command inside the docker container to create wallets for validators. The data is then forwarded to the directory created previously.
 
 ```bash
+chown -R 999 .
 docker run -it --rm -v $(pwd)/node/config:/opt/klever-blockchain \
-    --user "$(id -u):$(id -g)" \
     --entrypoint='' kleverapp/klever-go:latest keygenerator
 ```
 
@@ -144,8 +146,8 @@ The command for running a node comes with a few settings: it includes mappings f
 _MainNet_
 
 ```bash
+chown -R 999 .
 docker run -it --rm \
-    --user "$(id -u):$(id -g)" \
     --name klever-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -182,8 +184,8 @@ When you are done setting up and running your node, you are expected to see info
 When running in the background, add parameter `--use-log-view` and replace `--rm` for `-d`
 
 ```bash
+chown -R 999 .
 docker run -it -d --restart unless-stopped \
-    --user "$(id -u):$(id -g)" \
     --name klever-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -255,8 +257,8 @@ mkdir -p $(pwd)/node/config $(pwd)/node/db $(pwd)/node/logs
 Execute a command inside the docker container to create wallets for validators. The data is then forwarded to the directory created previously.
 
 ```bash
+chown -R 999 .
 docker run -it --rm -v $(pwd)/node:/opt/klever-blockchain \
-    --user "$(id -u):$(id -g)" \
     --entrypoint='' kleverapp/klever-go:latest keygenerator
 ```
 
@@ -265,8 +267,8 @@ docker run -it --rm -v $(pwd)/node:/opt/klever-blockchain \
 The command for running a node comes with a few settings: it includes mappings for cryptographic keys, data directories and logs, as well as network ports, the application that will run when the docker image is executed and the file of node validators signature.
 
 ```bash
+chown -R 999 .
 docker run -it --rm \
-    --user "$(id -u):$(id -g)" \
     --name klever-node \
     -v $(pwd)/node/confgi:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -542,8 +544,8 @@ preferences:
 Use the same docker command as a regular node, but ensure your `config.yaml` file has the correct `redundancyLevel`:
 
 ```bash
+chown -R 999 .
 docker run -it --rm \
-    --user "$(id -u):$(id -g)" \
     --name klever-fallback-node \
     -v $(pwd)/node/config:/opt/klever-blockchain/config/node \
     -v $(pwd)/node/db:/opt/klever-blockchain/db \
@@ -582,7 +584,8 @@ Or if you are using a self-hosted node, use `--network=host` to access the local
 Send tokens with the following code:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -605,7 +608,8 @@ If no `--kda` is passed, as in the example above, the default KDA is KLV.
 Here is another example, sending KFI:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -662,7 +666,8 @@ operator [command] [arguments] --[flags]
 If you are using the docker image operator, use the generic command version:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/smart-contracts/reference/upgrading/page.mdx
+++ b/src/app/smart-contracts/reference/upgrading/page.mdx
@@ -3,15 +3,16 @@
 Upgrading a smart contract is quite simple, although the effects might not be very clear. Just run this command to upgrade it:
 
 ```
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd):/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
     kleverapp/klever-go:latest  --key-file=KEY_FILE \
-    cc upgrade SC_ADDRESS --wasm=WASM_PATH \
-    --vmType=0500 --arguments example --payable --payableBySC --readable --upgradeable
+    sc upgrade SC_ADDRESS --wasm=WASM_PATH \
+     --args example --payable --payableBySC --readable --upgradeable
 ```
 
-Replace SC_ADDRESS, KEY_FILE and WASM_PATH accordingly. If needs arguments, add --arguments VALUE.
+Replace SC_ADDRESS, KEY_FILE and WASM_PATH accordingly. If needs arguments, add --args VALUE.
 
 Check your flags --payable --payableBySC --readable --upgradeable to make sure they are correct.

--- a/src/app/smart-contracts/reference/upgrading/page.mdx
+++ b/src/app/smart-contracts/reference/upgrading/page.mdx
@@ -2,8 +2,10 @@
 
 Upgrading a smart contract is quite simple, although the effects might not be very clear. Just run this command to upgrade it:
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd):/opt/klever-blockchain \
     --network=host \

--- a/src/app/staking/page.mdx
+++ b/src/app/staking/page.mdx
@@ -36,7 +36,8 @@ This means that the owner of the KDA with FPR will be responsible to their staki
 In order to freeze KLV, you should type the following code:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -60,7 +61,8 @@ The minimum amount allowed to stake KLV is 1000 KLV.
 To unfreeze assets, you need to run the follwoing command, signaling the bucket ID, which was generated when you first staked those assets:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -79,7 +81,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 Withdrawing assets will remove the values of all the unfrozen buckets automatically. This is how you should do it:
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -95,7 +98,8 @@ docker run -it --rm --user "$(id -u):$(id -g)" \
 You can claim rewards either from Staking (with no delegation) or Allowance (from delegation):
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \
@@ -127,13 +131,14 @@ First of all, you need to create a KDA. Use the Create Asset Contract to create 
 PS: You can not upgrade an existing KDA from APR to FPR Support.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \\
-    -v $(pwd)/wallet:/opt/klever-blockchain \\
-    --network=host \\
-    --entrypoint=/usr/local/bin/operator \\
-    kleverapp/klever-go:latest \\
-    --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.org \\
+chown -R 999 .
+docker run -it --rm \
+    -v $(pwd)/wallet:/opt/klever-blockchain \
+    --network=host \
+    --entrypoint=/usr/local/bin/operator \
+    kleverapp/klever-go:latest \
+    --key-file=./walletKey.pem \
+    --node=https://node.mainnet.klever.org \
     kda create 0 --canBurn=true --canMint=true --canFreeze=true --canPause=true --canWipe=true --logo=LOGO_URL --maxSupply=AMOUNT_MAX --precision=6 --name=KDA_NAME --ticker=KDA_TICKER —-interestType 1
 ```
 
@@ -144,13 +149,14 @@ After you created or updated your KDA, you need to deposit KDA to your FPR pool 
 PS: you can deposit multiple KDAs to your FPR pool to pay rewards with them.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \\
-    -v $(pwd)/wallet:/opt/klever-blockchain \\
-    --network=host \\
-    --entrypoint=/usr/local/bin/operator \\
-    kleverapp/klever-go:latest \\
-    --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.org \\
+chown -R 999 .
+docker run -it --rm \
+    -v $(pwd)/wallet:/opt/klever-blockchain \
+    --network=host \
+    --entrypoint=/usr/local/bin/operator \
+    kleverapp/klever-go:latest \
+    --key-file=./walletKey.pem \
+    --node=https://node.mainnet.klever.org \
     kda deposit AMOUNT --depositType=0 --kdaID=YOUR_KDA_ID --currencyID=KDA_YOU_WANT_TO_PAY_REWARDS
 ```
 
@@ -163,13 +169,14 @@ If you are a holder and want to receive rewards.
 To be able to receive rewards of a KDA with FPR you need to freeze this KDA with the following command. Make sure the asset you’re freezing supports FPR.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \\
-    -v $(pwd)/wallet:/opt/klever-blockchain \\
-    --network=host \\
-    --entrypoint=/usr/local/bin/operator \\
-    kleverapp/klever-go:latest \\
-    --key-file=./walletKey.pem \\
-    --node=https://node.mainnet.klever.org \\
+chown -R 999 .
+docker run -it --rm \
+    -v $(pwd)/wallet:/opt/klever-blockchain \
+    --network=host \
+    --entrypoint=/usr/local/bin/operator \
+    kleverapp/klever-go:latest \
+    --key-file=./walletKey.pem \
+    --node=https://node.mainnet.klever.org \
     account freeze AMOUNT --kda=KDA_id_YOU_WANT_TO_FREEZE
 ```
 
@@ -180,7 +187,8 @@ After the reward is generated, you can claim it with the following command:
 PS: You need to claim your rewards at least 100 epochs after the reward is generated.
 
 ```bash
-docker run -it --rm --user "$(id -u):$(id -g)" \
+chown -R 999 .
+docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
     --entrypoint=/usr/local/bin/operator \

--- a/src/app/staking/page.mdx
+++ b/src/app/staking/page.mdx
@@ -35,8 +35,10 @@ This means that the owner of the KDA with FPR will be responsible to their staki
 
 In order to freeze KLV, you should type the following code:
 
+<Note color="yellow">
+    **Warning:** Before running the following Docker commands, you'll need to change the ownership of your local files to user ID 999: `chown -R 999 .`
+</Note>
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -61,7 +63,6 @@ The minimum amount allowed to stake KLV is 1000 KLV.
 To unfreeze assets, you need to run the follwoing command, signaling the bucket ID, which was generated when you first staked those assets:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -81,7 +82,6 @@ docker run -it --rm \
 Withdrawing assets will remove the values of all the unfrozen buckets automatically. This is how you should do it:
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -98,7 +98,6 @@ docker run -it --rm \
 You can claim rewards either from Staking (with no delegation) or Allowance (from delegation):
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -131,7 +130,6 @@ First of all, you need to create a KDA. Use the Create Asset Contract to create 
 PS: You can not upgrade an existing KDA from APR to FPR Support.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -149,7 +147,6 @@ After you created or updated your KDA, you need to deposit KDA to your FPR pool 
 PS: you can deposit multiple KDAs to your FPR pool to pay rewards with them.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -169,7 +166,6 @@ If you are a holder and want to receive rewards.
 To be able to receive rewards of a KDA with FPR you need to freeze this KDA with the following command. Make sure the asset you’re freezing supports FPR.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \
@@ -187,7 +183,6 @@ After the reward is generated, you can claim it with the following command:
 PS: You need to claim your rewards at least 100 epochs after the reward is generated.
 
 ```bash
-chown -R 999 .
 docker run -it --rm \
     -v $(pwd)/wallet:/opt/klever-blockchain \
     --network=host \

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -42,10 +42,21 @@ function InfoIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   )
 }
 
-export function Note({ children }: { children: React.ReactNode }) {
+export function Note({ children, color = 'fuchsia' }: { children: React.ReactNode; color?: 'fuchsia' | 'yellow' }) {
+  const colorClasses = {
+    fuchsia: {
+      container: "border-fuchsia-500/20 bg-fuchsia-50/50 text-fuchsia-900 dark:border-fuchsia-500/30 dark:bg-fuchsia-500/5 dark:text-fuchsia-200 dark:[--tw-prose-links-hover:theme(colors.fuchsia.300)] dark:[--tw-prose-links:theme(colors.white)]",
+      icon: "fill-fuchsia-500 stroke-white dark:fill-fuchsia-200/20 dark:stroke-fuchsia-200"
+    },
+    yellow: {
+      container: "border-yellow-500/20 bg-yellow-50/50 text-yellow-900 dark:border-yellow-500/30 dark:bg-yellow-500/5 dark:text-yellow-200 dark:[--tw-prose-links-hover:theme(colors.yellow.300)] dark:[--tw-prose-links:theme(colors.white)]",
+      icon: "fill-yellow-500 stroke-white dark:fill-yellow-200/20 dark:stroke-yellow-200"
+    }
+  }
+
   return (
-    <div className="my-6 flex gap-2.5 rounded-2xl border border-fuchsia-500/20 bg-fuchsia-50/50 p-4 leading-6 text-fuchsia-900 dark:border-fuchsia-500/30 dark:bg-fuchsia-500/5 dark:text-fuchsia-200 dark:[--tw-prose-links-hover:theme(colors.fucshia.300)] dark:[--tw-prose-links:theme(colors.white)]">
-      <InfoIcon className="mt-1 h-4 w-4 flex-none fill-fuchsia-500 stroke-white dark:fill-fuchsia-200/20 dark:stroke-fuchsia-200" />
+    <div className={`my-6 flex gap-2.5 rounded-2xl border p-4 leading-6 ${colorClasses[color].container}`}>
+      <InfoIcon className={`mt-1 h-4 w-4 flex-none ${colorClasses[color].icon}`} />
       <div className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">
         {children}
       </div>


### PR DESCRIPTION
This pull request updates the documentation for running Docker commands across multiple `.mdx` files to improve clarity and user experience. The main changes are the removal of the `--user "$(id -u):$(id -g)"` flag from Docker commands and the addition of warnings about file ownership requirements. There are also minor improvements to command syntax and argument naming for consistency.

**Docker command usage improvements:**

* Removed the `--user "$(id -u):$(id -g)"` flag from all Docker command examples, simplifying instructions and standardizing usage across documentation. [[1]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfR153-R157) [[2]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfL169-R172) [[3]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfR276-R281) [[4]](diffhunk://#diff-414f502e15c5099796d2d25f06e86c236b4dc1ff644bf5703d5f57110d6cfd39R134-R138) [[5]](diffhunk://#diff-414f502e15c5099796d2d25f06e86c236b4dc1ff644bf5703d5f57110d6cfd39L148-R151) [[6]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aR11-R15) [[7]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL54-R57) [[8]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL77-R80) [[9]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL102-R105) [[10]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aL122-R125) [[11]](diffhunk://#diff-caec9d079a08b9f00077aa1601d7cafee5a4702834d4668671eab7aa8f05b405R17-L19) [[12]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380R15-R19) [[13]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380L39-R42) [[14]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380L62-R65) [[15]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL71-R75) [[16]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL86-R90) [[17]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL136) [[18]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL148) [[19]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL186) [[20]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL259) [[21]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL269) [[22]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL546) [[23]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL585-R583) [[24]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL608-R606) [[25]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caL665-R663) [[26]](diffhunk://#diff-36f167fadeb6663afb6a436018864c8622066dacd50365fd15fee21a621e99dcR5-R18) [[27]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3R38-R42) [[28]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L63-R66) [[29]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L82-R85) [[30]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L98-R101) [[31]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3L130-R139)

* Added a yellow warning note before Docker command sections instructing users to change file ownership to user ID 999 (`chown -R 999 .`) to prevent permission issues when running containers without the `--user` flag. [[1]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfR153-R157) [[2]](diffhunk://#diff-0523c73e4dec7e2e2d4cf4afe2348399ec132ad595178b3f757aedba67d2aecfR276-R281) [[3]](diffhunk://#diff-414f502e15c5099796d2d25f06e86c236b4dc1ff644bf5703d5f57110d6cfd39R134-R138) [[4]](diffhunk://#diff-15cd7fe6454d264b94765814541a11040ca87719d5e9406d38484cd48d42642aR11-R15) [[5]](diffhunk://#diff-caec9d079a08b9f00077aa1601d7cafee5a4702834d4668671eab7aa8f05b405R17-L19) [[6]](diffhunk://#diff-c11bdb20e3a22a833375cebed3a8916f1754b8a7f3efdc036a83a65c565f5380R15-R19) [[7]](diffhunk://#diff-f1dd432dd5415709e31ee414ae2036cafcb343431541aec7a6e39db79cc7e9caR62-R65) [[8]](diffhunk://#diff-36f167fadeb6663afb6a436018864c8622066dacd50365fd15fee21a621e99dcR5-R18) [[9]](diffhunk://#diff-fffea422b42a21dd5b4fa6704ce46e6cafe65dfe75c1553c30216a6316e43aa3R38-R42)

**Command and argument consistency:**

* Updated the smart contract upgrade command to use `sc upgrade` and `--args` instead of `cc upgrade` and `--arguments` for clarity and accuracy.

* Minor formatting and consistency improvements to multi-line Docker commands in staking documentation.

These changes make the documentation more user-friendly, reduce potential permission errors, and ensure consistency in command usage throughout the project.