### PR TITLE
[KLC-2068] Update smart contracts payment reference

### DIFF
--- a/src/app/smart-contracts/reference/payments/page.mdx
+++ b/src/app/smart-contracts/reference/payments/page.mdx
@@ -62,14 +62,14 @@ payments.iter().for_each(|payment| {
 });
 ```
 
-Payment objects (KdaTokenPayment) store three variables that you can use to assert the token and also gather the amount 
+Payment objects (KdaTokenPayment) store three variables that you can use to assert the token and also gather the amount:
 ```rust
 let amount = payment.amount;
 let token = payment.token_identifier;
 let token_nonce = payment.token_nonce;
 ```
 
-If your endpoint only receives KLV, we provide a shortcut to access the transfer amount directly
+If your endpoint only receives KLV, we provide a shortcut to access the transfer amount directly:
 ```rust
 let amount = self.call_value().klv_value();
 ```

--- a/src/app/smart-contracts/reference/payments/page.mdx
+++ b/src/app/smart-contracts/reference/payments/page.mdx
@@ -4,8 +4,6 @@
 
 This section aims to provide a comprehensive guide on how smart contracts handle payments, focusing on both receiving and sending tokens.
 
-> Note: On the Klever network, it is not possible to simultaneously send KLV and any KDA token. Consequently, you will not find any syntax supporting the transfer of both in either receiving or sending scenarios.
-
 ---
 
 ## Methods of Receiving Payments
@@ -50,6 +48,31 @@ fn accept_any_payment(&self) {
 ```
 
 > Note: It's possible to hard-code a specific token identifier in the `payable` attribute, like `#[payable("MYTOKEN-123456")]`. This is a less common practice, as tokens are typically configured in storage or at runtime.
+
+To read the payment details on single-token transfers, you can use:
+```rust
+let payment = self.call_value().single_kda();
+```
+
+To read the payment details on multi-token transfers, you can use:
+```rust
+let payments = self.call_value().all_kda_transfers();
+payments.iter().for_each(|payment| {
+	// payment handling...
+});
+```
+
+Payment objects (KdaTokenPayment) store three variables that you can use to assert the token and also gather the amount 
+```rust
+let amount = payment.amount;
+let token = payment.token_identifier;
+let token_nonce = payment.token_nonce;
+```
+
+If your endpoint only receives KLV, we provide a shortcut to access the transfer amount directly
+```rust
+let amount = self.call_value().klv_value();
+```
 
 You can impose additional restrictions on incoming tokens within the endpoint's body by utilizing the call value API, which provides various functions for managing expected payments.
 


### PR DESCRIPTION
This pull request updates the documentation for handling payments in smart contracts, focusing on how to read payment details for different token transfer scenarios. The main improvements are clearer instructions and code examples for accessing payment information when receiving single-token, multi-token, and KLV payments.

**Documentation improvements for payment handling:**

* Added code examples showing how to read payment details for single-token transfers using `self.call_value().single_kda()` and for multi-token transfers using `self.call_value().all_kda_transfers()`.
* Explained how to access properties of `KdaTokenPayment` objects, such as `amount`, `token_identifier`, and `token_nonce`.
* Provided a shortcut example for accessing the KLV transfer amount with `self.call_value().klv_value()`.

**Other changes:**

* Removed a note about the impossibility of sending KLV and KDA tokens simultaneously, 