### PR TITLE
[KLC-2326] Update code metadata upgrade flags

### DIFF
--- a/src/app/smart-contracts/data/code-metadata/page.mdx
+++ b/src/app/smart-contracts/data/code-metadata/page.mdx
@@ -21,8 +21,8 @@ Code metadata consists of flags representing the allowed actions of a smart cont
 
 When deploying or upgrading a smart contract using **koperator**, the default _code metadata flags_ are only `upgradeable`. These default values can be overwritten by using the following options with the `koperator sc create` or `koperator sc upgrade` commands:
 
-- `--upgradeable` - marks the contract as **non-** `upgradeable`.
-- `--readable` - marks the contract as **non-** `readable`.
+- `--upgradeable` - marks the contract as `upgradeable`.
+- `--readable` - marks the contract as `readable`.
 - `--payable` - marks the contract as `payable`.
 - `--payableBySc` - marks the contract as `payable by smart contracts`.
 


### PR DESCRIPTION
This pull request corrects the documentation for the `koperator` command options related to smart contract code metadata flags. The descriptions for the `--upgradeable` and `--readable` flags have been fixed to accurately reflect their behavior.

Documentation corrections:

* Updated the descriptions of the `--upgradeable` and `--readable` flags to indicate that they mark the contract as `upgradeable` and `readable`, respectively, instead of the incorrect **non-** versions.