### PR TITLE
[KLC-2450] Add node API hardening guide

### DIFF
--- a/src/app/node-operations/securing-the-api/page.mdx
+++ b/src/app/node-operations/securing-the-api/page.mdx
@@ -1,0 +1,157 @@
+# Securing the Node API
+
+The node exposes a REST and WebSocket API. It performs **no origin checking and no access control of
+its own** — whether it is safe depends entirely on how you deploy it. This guide covers what the
+defaults are, what changes when you expose the API, and how to configure it for a public deployment.
+
+## The exposure model
+
+By default the API binds to `localhost:8080`, reachable only from the node host itself. That default
+is safe, and most operators should leave it alone.
+
+Exposing the API beyond localhost is a deliberate choice, and the node does not second-guess it. If
+you expose it, it **must** be fronted by a reverse proxy that:
+
+- terminates TLS,
+- enforces origin / CORS policy,
+- requires authentication.
+
+Firewall the API port so the node is reachable only through that proxy.
+
+<Note>
+The node will not reject a cross-origin request on its own. Origin policy is deliberately left to the
+proxy, which means an exposed node with no proxy in front of it has no origin protection at all.
+</Note>
+
+### Do not run a browser on a validator host
+
+Because the API has no origin control, any web page you visit on that machine can issue cross-origin
+requests to `localhost:8080` and reach your node. Keep validator hosts headless.
+
+## Route configuration
+
+Routes live in `config/node/api.yaml`. Two flags govern each route, and combined they do not behave
+the way the names suggest:
+
+| Flag | Meaning |
+|---|---|
+| `open` | whether the route is **registered at all** |
+| `secured` | attaches Basic Auth to a route that is **already open** |
+
+<Note>
+**`secured: true` together with `open: false` does not give you an authenticated endpoint — it gives
+you no endpoint.** The route is simply not registered. The node logs a warning for `/subscribe` in
+this case, but not for every route, so verify your config rather than relying on a log line.
+</Note>
+
+### `/log`
+
+Ships **enabled and authenticated** (`open: true`, `secured: true`).
+
+It streams node-wide logs, which can include operational detail you would not want public. Keep
+`secured: true` if the API is reachable off-host, or set `open: false` to remove the route entirely.
+
+### `/subscribe`
+
+Ships **enabled and unauthenticated** (`open: true`, no `secured`). It is a public event feed by
+design.
+
+For a public or mainnet deployment, either add `secured: true` to require Basic Auth on the
+handshake, or set `open: false` to disable it. See [WebSocket limits](#websocket-limits) for its
+resource controls.
+
+## Credentials
+
+Authentication is HTTP Basic Auth. The `password` field in `api.yaml` is **not** the password — it is
+the **hex-encoded digest** of the password under the configured hasher (`sha256` by default).
+
+The shipped entries are placeholders and will not work:
+
+```yaml
+credentials:
+  - username: example
+    password: hashed password
+hasher:
+  type: sha256
+```
+
+Generate a real digest:
+
+```bash
+printf '%s' 'your-password' | sha256sum | cut -d' ' -f1
+```
+
+<Note>
+Leaving the `credentials` list **empty** does not disable authentication — it makes every
+authenticated request fail with HTTP 500. Configure real credentials before enabling `secured`
+anywhere.
+</Note>
+
+## Recommended hardened configuration
+
+For a node whose API is reachable off-host, start here and adjust:
+
+```yaml
+# config/node/api.yaml
+  log:
+    routes:
+      - name: /log
+        open: true
+        secured: true       # or open: false to remove the route entirely
+  subscribe:
+    routes:
+      - name: /subscribe
+        open: true
+        secured: true       # public feed by default; require auth when exposed
+
+credentials:
+  - username: <operator>
+    password: <hex sha256 digest of the password>
+hasher:
+  type: sha256
+```
+
+Pair that with either the default `--rest-api-interface=localhost:8080` plus a reverse proxy, or a
+firewall rule restricting the port to the proxy host.
+
+## WebSocket limits
+
+`/subscribe` connection and subscription limits are tunable under `webServer` in
+`config/node/config.yaml`:
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `webSocketConnections` | `4096` | node-wide cap on live connections |
+| `webSocketConnectionsPerIP` | `1024` | per-source-IP cap |
+| `webSocketMaxAddressesPerSubscribe` | `10000` | addresses accepted in one subscribe call |
+| `webSocketMaxAddressesPerClient` | `50000` | total addresses one connection may watch |
+
+Setting any of these to `0` means unlimited.
+
+<Note>
+**Behind a reverse proxy, every client shares the proxy's IP**, so `webSocketConnectionsPerIP` will
+throttle all of them together. Raise it — or set it to `0` and enforce per-client limits at the proxy
+instead.
+</Note>
+
+The general HTTP throttlers (`simultaneousRequests`, `sameSourceRequests`) release their slot at the
+HTTP-to-WebSocket upgrade, so they do not bound live WebSocket connections. The `webSocket*` settings
+are what do.
+
+## Checklist
+
+- [ ] API bound to `localhost` unless deliberately exposed
+- [ ] If exposed: reverse proxy enforcing TLS, origin/CORS, and authentication
+- [ ] API port firewalled to the proxy host
+- [ ] Real credentials configured; placeholders replaced
+- [ ] `/log` secured, or disabled
+- [ ] `/subscribe` secured or disabled if it should not be public
+- [ ] `webSocketConnectionsPerIP` adjusted if behind a proxy
+- [ ] No browser running on validator hosts
+- [ ] Node software kept up to date
+- [ ] Secure key management practices followed
+
+## Related
+
+- [Node Operations](/node-operations) — installing, running, and upgrading a node
+- [Become a Validator](/become-a-validator) — validator setup and staking

--- a/src/consts/navigation.ts
+++ b/src/consts/navigation.ts
@@ -204,7 +204,13 @@ export const navigation: Array<NavGroup> = [
       { title: 'Testnet', href: '/testnet' },
       { title: 'Contracts', href: '/contracts' },
       { title: 'Exchange Integration', href: '/exchange-integration' },
-      { title: 'Node Operations', href: '/node-operations' },
+      {
+        title: 'Node Operations',
+        href: '/node-operations',
+        children: [
+          { title: 'Securing the Node API', href: '/securing-the-api' },
+        ],
+      },
       {
         title: 'Bridge',
         href: '/bridge',


### PR DESCRIPTION
Adds a "Securing the Node API" page under Node Operations, covering how the REST/WS API should be deployed. The companion `SECURITY.md` section lives in a separate PR on the node repo.

Node operators currently have no published guidance on exposing the API. The node performs no origin checking and no access control of its own — that is a deliberate design position, with policy delegated to a reverse proxy — but it is only a defensible position if operators are told. This page states the defaults plainly, explains what changes when the API is exposed, and gives a configuration to copy.

## What's here

A new page at `/node-operations/securing-the-api`, linked as a child of Node Operations in the sidebar. It covers the exposure model and reverse-proxy requirement, per-endpoint guidance for `/log` and `/subscribe`, the credential format, a hardened configuration block, the WebSocket limits, and a checklist.

## Two things operators reliably get wrong

Both are called out with `<Note>` callouts rather than buried in prose:

**`secured: true` together with `open: false` gives you no endpoint, not a protected one.** `open` decides whether the route is registered at all; `secured` only attaches Basic Auth to a route that is already open. The combination reads like "authenticated and locked down" and actually means "absent".

**The `password` field is a hex-encoded sha256 digest, not a password.** The shipped `credentials` entries are placeholders and will not authenticate anything, and leaving the list empty does not disable authentication — it fails every request with HTTP 500. The page includes the one-liner for generating a valid digest.

Also worth knowing, and included: behind a reverse proxy every client shares the proxy's IP, so `webSocketConnectionsPerIP` throttles all of them together and should be raised or disabled in favour of per-client limits at the proxy.

## Verification

`pnpm build` passes and the route is generated:

```
├ ○ /node-operations/securing-the-api
```

Every configuration default and behaviour described here was checked against the node source rather than taken from the ticket — including three claims in the original ticket that are now stale and were deliberately not repeated.

The `<Note>` component was already exported from `src/components/mdx.tsx` and spread into MDX by `mdx-components.tsx`; this is the first page to use it.
